### PR TITLE
Fix setting save and value evaluation issues.

### DIFF
--- a/core/components/crosscontextssettings/processors/mgr/settings/updatefromgrid.class.php
+++ b/core/components/crosscontextssettings/processors/mgr/settings/updatefromgrid.class.php
@@ -57,7 +57,7 @@ class SettingUpdateFromGridProcessor extends modObjectProcessor {
                 'key' => $props['key'],
                 'context_key' => $k,
             ));
-            if (!empty($v)) {
+            if (!empty($v) || $v === '0') {
                 if (!$setting) {
                     if (isset($props[$k])) {
                         $setting = $this->modx->newObject($this->classKey);
@@ -72,6 +72,9 @@ class SettingUpdateFromGridProcessor extends modObjectProcessor {
                             return $this->failure($message);
                         }
                     }
+                    continue;
+                }
+                if($setting->get('value') === $props[$k]) { //Skip saving same value
                     continue;
                 }
                 $setting->set('value', $props[$k]);


### PR DESCRIPTION
1- Evaluating "0" as a value . (Line 60) issue #8
2- No need to save a setting again while it has exact same value. (line 77)
